### PR TITLE
Fix set_version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ then, in your specs:
 
 If you want to run a specific version of chromedriver, you can set the version like so:
 
-    Chromedriver.set_version = "2.24"
+    Chromedriver.set_version "2.24"
 
 # Updating to latest Chromedriver
 


### PR DESCRIPTION
The documented way to set the version isn't quite correct - the method name doesn't include the `=`.

The error was:
```
undefined method `set_version=' for Chromedriver:Module
Did you mean?  set_version (NoMethodError)
/Users/jamiecobbett/code/livestax/config/initializers/chromedriver.rb:17:in `<top (required)>'
```